### PR TITLE
Add return on error during Config.GenerateModifyInputs()

### DIFF
--- a/app/modify.go
+++ b/app/modify.go
@@ -130,6 +130,7 @@ func (a *App) gribiModify(ctx context.Context, t *target) chan *modifyResponse {
 					Err:        err,
 				},
 			}
+			return
 		}
 
 		// session parameters


### PR DESCRIPTION
Added a return statement to bail out early if we encounter an error after calling Config.GenerateModifyInputs() method, this prevents runtime panics in case of incorrect yaml inputs, e.g.
```
$ gribic --config target.yml modify --input-file crash-set 
INFO[0000] trying to find variable file "crash-set_vars" 
INFO[0000] target XXXXX modify stream done   
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x192ff46]

goroutine 24 [running]:
github.com/karimra/gribic/app.(*App).createModifyRequestParams(0xc0006c9500?, 0xc00003e980?)
	/home/runner/work/gribic/gribic/app/modify.go:232 +0x26
github.com/karimra/gribic/app.(*App).gribiModify.func1()
	/home/runner/work/gribic/gribic/app/modify.go:136 +0x27d
created by github.com/karimra/gribic/app.(*App).gribiModify
	/home/runner/work/gribic/gribic/app/modify.go:109 +0x14a
```